### PR TITLE
Add text auto selection in pre elements

### DIFF
--- a/_layouts/root.html
+++ b/_layouts/root.html
@@ -126,23 +126,35 @@ This page was saved from: {{site.url}}{{page.url}}
 <!-- Auto select text in preformatted elements on click. -->
 <script>
 	if(document.addEventListener) document.addEventListener('DOMContentLoaded', function() {
-		function selectText() {
-			var sel = document.getSelection();
-			var rng = document.createRange();
+		function trimPreText(pre) {
+			var child = pre.querySelector('code');
+			var target = child ? child : pre;
 
-			sel.removeAllRanges();
-			rng.selectNodeContents(this);
-			sel.addRange(rng);
+			target.innerHTML = target.innerHTML.trim();
+		}
+
+		function injectPreTextSelectionHelper(pre) {
+			var control = document.createElement('div');
+
+			control.className = 'pre-text-selection-helper';
+
+			control.addEventListener('click', function() {
+				var selection = document.getSelection();
+				var range = document.createRange();
+
+				selection.removeAllRanges();
+				range.selectNodeContents(this.nextSibling);
+				selection.addRange(range);
+			});
+
+			snippets[i].parentNode.insertBefore(control, snippets[i]);
 		}
 
 		var snippets = document.querySelectorAll('.content pre');
 
 		for(var i = 0; i < snippets.length; ++i) {
-			var child = snippets[i].querySelector('code');
-			var target = child ? child : snippets[i];
-
-			target.innerHTML = target.innerHTML.trim();
-			snippets[i].addEventListener('click', selectText);
+			trimPreText(snippets[i]);
+			injectPreTextSelectionHelper(snippets[i]);
 		}
 	});
 </script>

--- a/main.css
+++ b/main.css
@@ -31,7 +31,7 @@ div {
 }
 
 .wrapper {
-  margin: 0 auto; 
+  margin: 0 auto;
   min-height: 100%;
   background-color: #fdf6e3;
   -webkit-box-shadow: 0 0 8px 3px #93a1a1;
@@ -148,6 +148,40 @@ pre.prettyprint {
 code.install {
   width: 50em;
   white-space: normal;
+}
+
+/* Scaffolding for text auto-selection in preformatted elements */
+.pre-text-selection-helper {
+  display: block;
+  position: relative;
+  margin-top: 2.5em;
+  cursor: pointer;
+}
+
+.pre-text-selection-helper::after {
+  content: 'Select All';
+  position: absolute;
+  z-index: 0;
+  background-color: #93a1a1;
+  color: #000;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  top: -26px;
+  letter-spacing: 1px;
+  padding: 5px 12px;
+  font-size: 0.875em;
+  box-shadow: 2px 2px 3px #839496;
+}
+
+.pre-text-selection-helper:hover::after {
+  color: #fafafa;
+  text-shadow: 1px 1px 1px #000;
+}
+
+.pre-text-selection-helper + pre {
+  border-top-left-radius: 0;
+  position: relative;
+  z-index: 1;
 }
 
 @media (max-width: 980px) {


### PR DESCRIPTION
As demonstrated below, [long command samples](http://conemu.github.io/en/AutoInstall.html) can be awkward to copy & paste.

![conemu-current](https://cloud.githubusercontent.com/assets/6773893/9565906/efea3ee8-4eb9-11e5-975c-090bb382bd13.gif)

This PR implements "click-to-select" functionality for `pre` elements for easier command copying as shown below.

![conemu-proposed](https://cloud.githubusercontent.com/assets/6773893/9565913/47651a94-4eba-11e5-9a09-e22cc8223a21.gif)

In addition to implementing auto text selection, string contents are trimmed to prevent accidental trailing newline injection during single-line pasting.

Furthermore, the script has been added to the master template in order to propagate this functionality site-wide and should work in browsers newer than IE8. Since ConEmu is targeted at power users, I don't think this is a problem.
