### PR TITLE
Fixed RightShift to RightControl

### DIFF
--- a/en/AppsKey.md
+++ b/en/AppsKey.md
@@ -13,7 +13,7 @@ breadcrumbs:
 # What is an Apps key?
 
 This key (mentioned as `VK_APPS` in `WinUser.h`)
-is located between `RightWin` and `RightShift` on the most of
+is located between `RightWin` and `RightControl` on the most of
 [keyboard layouts](http://en.wikipedia.org/wiki/File:Klawiatura_maszynistki.jpg).
 
 Sometimes it's called `Application/Menu`.


### PR DESCRIPTION
Saying that this key is located between `RightWin` and `RightShift` was incorrect, since the `Shift` key isn't even on the same row – it's *above* the Apps key. According to the image, and consistent with almost all keyboards, the `RightControl` key is on the right side of the Apps key.

(You might want to mention that this key is commonly known as the Menu key: https://en.wikipedia.org/wiki/Menu_key)