### PR TITLE
Safer way to set CWD in zsh

### DIFF
--- a/en/ShellWorkDir.md
+++ b/en/ShellWorkDir.md
@@ -152,9 +152,8 @@ fi
 For zsh just add this to your `~/.zshrc` file.
 
 ~~~
-prmptcmd() { eval "$PROMPT_COMMAND" }
-precmd_functions=(prmptcmd)
-PROMPT_COMMAND='ConEmuC -StoreCWD'
+set_conemu_cwd() { ConEmuC -StoreCWD }
+precmd_functions+=set_conemu_cwd
 ~~~
 
 


### PR DESCRIPTION
The new implementation adds to the `precmd` hook function instead of overwriting it. This makes it work better with zsh prompts / themes themes that often customize `precmd`.

Tested in MSYS2 + zsh + this ConEmu task:

> set CHERE_INVOKING=1 & set MSYSTEM=MINGW64 & set MSYS2_PATH_TYPE=inherit & set "PATH=%ConEmuDrive%\msys64\mingw64\bin;%ConEmuDrive%\msys64\usr\bin;%PATH%" & %ConEmuBaseDirShort%\conemu-msys2-64.exe -new_console:p %ConEmuDrive%\msys64\usr\bin\zsh.exe --login -i -new_console:C:"%ConEmuDrive%\msys64\msys2.ico"