### PR TITLE
Change clink URL

### DIFF
--- a/en/SettingsFeatures.md
+++ b/en/SettingsFeatures.md
@@ -51,7 +51,7 @@ Allow injecting ConEmuHk.dll in every process of ConEmu console window. Required
 Enables DosBox integration
 
 #### Use Clink in prompt  {#id2418}
-Use clink to extend command prompt (cmd.exe) https://mridgers.github.io/clink/
+Use clink to extend command prompt (cmd.exe) https://chrisant996.github.io/clink/
 
 #### ANSI and xterm sequences  {#id2253}
 Enable processing of ANSI escape sequences, ‘Inject ConEmuHk’ must be checked if you want to work with second level processes (e.g. cmd.exe -> app.exe)

--- a/en/TabCompletion.md
+++ b/en/TabCompletion.md
@@ -35,12 +35,12 @@ like in the [issue 225](https://github.com/Maximus5/ConEmu/issues/225).
 
 ## cmd.exe and clink  {#ConEmu_and_clink}
 
-If you are using `cmd.exe` as shell you may try [clink](http://mridgers.github.io/clink/)
+If you are using `cmd.exe` as shell you may try [clink](http://chrisant996.github.io/clink/)
 for bash style completion and advanced cmd prompt.
 ConEmu provides an [option](SettingsFeatures.html) to autoload clink in cmd tabs.
 
-* Download latest [clink](http://mridgers.github.io/clink/)
-  or build it yourself from [sources](https://github.com/mridgers/clink#building-clink).
+* Download latest [clink](http://chrisant996.github.io/clink/)
+  or build it yourself from [sources](https://github.com/chrisant996/clink#building-clink).
 * Unpack **files** (without subfolder) into `%ConEmuBaseDir%\clink`
   (this folder already created by ConEmu installer and contains `Readme.txt`).
   * Please note, clink archive contains subfolder. Files `clink_dll_x86.dll`, `clink_dll_x64.dll`
@@ -64,7 +64,7 @@ Actually, option ‘Use Clink in prompt’ is not required,
 if clink was set up using its installer.
 
 Please refer to
-[https://github.com/mridgers/clink](https://github.com/mridgers/clink)
+<https://github.com/chrisant996/clink>
 for further information and bugreports.
 
 


### PR DESCRIPTION
The original version of clink is not maintained any more (see e.g., https://github.com/mridgers/clink/pull/473).

This PR changes the links to the maintained fork https://chrisant996.github.io/clink/. It is the twin PR to https://github.com/Maximus5/ConEmu/pull/2242