### PR TITLE
Replace link in cmder.md

### DIFF
--- a/en/cmder.md
+++ b/en/cmder.md
@@ -11,7 +11,7 @@ breadcrumbs:
 
 # cmder
 
-[cmder](http://cmder.net/) is a preconfigured software bundle
+[cmder](https://cmder.app/) is a preconfigured software bundle
 of [ConEmu](https://conemu.github.io/) and some third-party software:
 
 * [Git for Windows](https://gitforwindows.org/);


### PR DESCRIPTION
cmder.net redirects to some scam now, so i replaced the link with the actual current site, cmder.app